### PR TITLE
Add a shared calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ There are many areas we can collaborate on. In some areas work is already being 
 
 - **[Conferences and Meetups](https://github.com/w3c/webcomponents-cg/labels/conferences-and-meetups)** - Organize conferences and meetups that include topics and participants from across the web components ecosystem.
 
+## Meetings
+
+The Web Components Community Group holds [a shared calendar](https://calendar.google.com/calendar/embed?src=o25bim5rvcu42mfnqilirpmp44%40group.calendar.google.com&ctz=America%2FLos_Angeles) of its meetings and events. A ics file if [available here](https://calendar.google.com/calendar/ical/o25bim5rvcu42mfnqilirpmp44%40group.calendar.google.com/public/basic.ics).
+
 ---
 
 A repository for the [Web Components Community Group](https://www.w3.org/community/webcomponents/)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are many areas we can collaborate on. In some areas work is already being 
 
 ## Meetings
 
-The Web Components Community Group holds [a shared calendar](https://calendar.google.com/calendar/embed?src=o25bim5rvcu42mfnqilirpmp44%40group.calendar.google.com&ctz=America%2FLos_Angeles) of its meetings and events. A ics file if [available here](https://calendar.google.com/calendar/ical/o25bim5rvcu42mfnqilirpmp44%40group.calendar.google.com/public/basic.ics).
+The Web Components Community Group holds [a shared calendar](https://calendar.google.com/calendar/embed?src=o25bim5rvcu42mfnqilirpmp44%40group.calendar.google.com) of its meetings and events. A ics file if [available here](https://calendar.google.com/calendar/ical/o25bim5rvcu42mfnqilirpmp44%40group.calendar.google.com/public/basic.ics).
 
 ---
 


### PR DESCRIPTION
I just missed a meeting and I'd love for us to use a shared calendar.

As I mentioned on Slack, this calendar is being used just an example and we can quickly upgrade it to a proper shared entry. Things to consider:

This PR makes the current calendar public. If our policies disallow this or if we want to keep some privacy over the meetings, we can create a new shared calendar and keep it elsewhere.

To upgrade this calendar to a proper shared state I'd like to:

- [ ] Add emails of those who are going to manage it and might eventually organize meetings.
- [ ] Remove the `[WIP]` prefix

Non blocking questions:

- Are we fine with the regular meetings being called "Web Components CG General Assembly"? I'm happy to rename it to anything else if necessary.
- Can we add a link to the notes document to the meetings entry?
