### PR TITLE
Foundations for spec status report

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,0 +1,27 @@
+name: Reports
+on:
+  pull_request:
+    paths: ['reports/**']
+  push:
+    branches: ['main', 'report']
+    paths: ['reports/**']
+  workflow_dispatch: {}
+
+jobs:
+  main:
+    name: Build and deploy technical reports
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - source: reports/status.html
+            destination: index.html
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          SOURCE: ${{ matrix.source }}
+          DESTINATION: ${{ matrix.destination }}
+          GH_PAGES_BRANCH: gh-pages

--- a/reports/status.html
+++ b/reports/status.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Web Components Community Group: 2021 Spec/API status</title>
+    <script
+      src="https://www.w3.org/Tools/respec/respec-w3c"
+      class="remove"
+      defer
+    ></script>
+    <script class="remove">
+      // All config options at https://respec.org/docs/
+      var respecConfig = {
+        specStatus: "CG-DRAFT",
+        latestVersion: null,
+        edDraftURI: null,
+        editors: [
+          {
+            name: "Westbrook Johnson",
+            url: "https://westbrookjohnson.com",
+          },
+        ],
+        github: "w3c/webcomponents-cg",
+        shortName: "webcomponents-cg",
+        xref: "web-platform",
+        group: "webcomponents",
+        tocIntroductory: true,
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>This is required.</p>
+    </section>
+    <section id="sotd">
+      <p>This is required.</p>
+    </section>
+    <section class="informative">
+      <h2>Introduction</h2>
+      <p>Some informative introductory text.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Feature or Problem</th>
+            <th>GitHub Issue(s)</th>
+            <th>Priority</th>
+            <th>Status(?)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>---</th>
+            <td>---</td>
+            <td>---</td>
+            <td>---</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Feature or Problem</h2>
+      <dl>
+        <dt>GitHub Issue(s):</dt>
+        <dd>---</dd>
+        <dt>Priority:</dt>
+        <dd>---</dd>
+        <dt>Status:</dt>
+        <dd>---</dd>
+      </dl>
+      <section>
+        <h3>Description</h3>
+        <p>---</p>
+      </section>
+      <section>
+        <h3>Motivation</h3>
+        <p>---</p>
+      </section>
+    </section>
+    <section id="conformance">
+      <p>
+        This is required for specifications that contain normative material.
+      </p>
+    </section>
+    <section id="index"></section>
+  </body>
+</html>


### PR DESCRIPTION
- Add GitHub action to publish to `gh-pages` using the `webcomponents` working group tag because respec doesn't currently support `webcomponents-cg` 🙈 
- Add skeleton page in celebration of October 👻 and prep it to accept content for various specs