### PR TITLE
Simplified childrenChangedCallback motivation section.

### DIFF
--- a/reports/status.html
+++ b/reports/status.html
@@ -396,9 +396,10 @@
       </section>
       <section>
         <h3>Motivation</h3>
-        <p>Establishing parent child relationships between components is a common pattern with custom elements. The challenge for the parent is to know when new children are inserted into its scope and act on those children. The parent doesn't have inherent insurance that the child element is upgraded by the custom element registry. Currently, developers are using a combination of mutation observers and slotchange events to be notified when new elements have entered its scope, then using polling, promise callbacks or `setTimeouts` to a "wait" for the child to finish upgrading.</p>
-        <p>Consider the following example.  A higher order app (`x-app`) component is in charge of orchestrating authenticating the user when the page initially loads.  To do that, it leverages the authentication component (`x-auth`) that is a child component.  Using the `childrenChangedCallback()` hook, `x-app` can be notified when new children are added to its scope and has the ability to immediately interface with it’s API.</p>
-        <p>Example: <a href="https://codepen.io/heyMP/pen/rNwXRWg">https://codepen.io/heyMP/pen/rNwXRWg</a></p>
+        <ul>
+          <li>Simplicity: Currently, developers are using a combination of mutation observers and slotchange events to be notified when new elements have entered or removed from its scope. This would be replaced by a single callback function on the parent element.</li>
+          <li>Children upgraded: When new children enter the parents scope there is no way of deterministically knowing that the child element has been upgraded with its custom element definition. Developers resort to polling, promise callbacks or timeouts to then wait for the child to finish upgrading before calling its APIs. The proposed callback would contain elements that have already been upgraded.</li>
+        </ul>
       </section>
     </section>
     <section>


### PR DESCRIPTION
I converted the argument from and example to bullet list improvements.