### PR TITLE
Update DSD section with link to GitHub and usage of DSD in the wild

### DIFF
--- a/reports/2022.html
+++ b/reports/2022.html
@@ -763,7 +763,7 @@ class FancyInput extends HTMLElement {
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>Mozilla would like to see more <a href="https://github.com/whatwg/dom/issues/831#issuecomment-988394185">real world uses cases</a> of Declarative Shadow DOM in the wild.  Which is a bit of a catch-22 when it is only supported in one browser and requires a polyfill.</li>
+          <li>Mozilla would like to see more <a href="https://github.com/whatwg/dom/issues/831#issuecomment-988394185">real world uses cases</a> of Declarative Shadow DOM in the wild.  <a href="https://github.com/whatwg/dom/issues/831#issuecomment-1204554491" target="_blank">GitHub has confirmed that they are using DSD</a> and see many architectural benefits from it, especially for their design system. Although a polyfill exists, it comes as a bit of a catch-22 when trying to target pure SSR Web Components (HTML) use cases.</li>
           <li>Safari would like to <a href="https://github.com/whatwg/dom/issues/831#issuecomment-797845645">get consensus on the solution for Scoped Element Registries first.</a></li>
         </ul>
       </section>


### PR DESCRIPTION
Addendum to #45 to link to GitHub as a real world use case of Declarative Shadow DOM.