### PR TITLE
fix typos and formatting

### DIFF
--- a/reports/2022.html
+++ b/reports/2022.html
@@ -486,7 +486,7 @@
                 &lt;li>Item 1&lt;/li>
                 &lt;li reflectariaactivedescendent>Item 2&lt;/li>
                 &lt;li>Item 3&lt;/li>
-              </ul>
+              &lt;/ul&gt;
             &lt;/template>
             &lt;x-foo id="foo">&lt;/x-foo>
           </code>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -74,7 +74,7 @@
         <h3>Spec Alignment</h3>
         <p>The following specs we see as highly valuable to the developer community for being able to deliver great web experiences to users when using Web Components.  As it pertains to topics like Aria and SSR, these specs just need a little more alignment across browser implementors so that consensus can be achieved.</p>
         <ul>
-          <li><a href="#cross-root-aria">Aria</a></li>
+          <li><a href="#cross-root-aria">Cross-root Aria</a></li>
           <li><a href="#scoped-element-registries">Scoped Registries</a></li>
           <li><a href="#declarative-shadow-dom">Declarative Shadow DOM</a></li>
         </ul>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -64,8 +64,8 @@
         <h3>Browser Parity</h3>
         <p>We noticed the following specs already have a high degree of alignment from an implementation perspective, but support in browsers is still not equally distributed.  Filling in these gaps would be a big win for users and developers alike for a more predictable web.</p>
         <ul>
-          <li><a href="#form-associated-custom-elements">FACE (Form-Associated Custom Elements</a></li>
-          <li><a href="#constructable-stylesheets-adoptedstylesheets">Constructible Style Sheets</a></li>
+          <li><a href="#form-associated-custom-elements">FACE (Form-Associated Custom Elements)</a></li>
+          <li><a href="#constructable-stylesheets-adoptedstylesheets">Constructable Style Sheets</a></li>
           <li><a href="#css-module-scripts">CSS Modules</a></li>
           <li><a href="#imperative-slot-assignment">Imperative slots</a></li>
         </ul>
@@ -101,7 +101,7 @@
               <td>Partial consensus, divergent partial implementations</td>
             </tr>
             <tr>
-              <th><a href="http://localhost:8080/status.html#constructable-stylesheets-adoptedstylesheets">Constructable Stylesheets & adoptedStyleSheets</a></th>
+              <th><a href="#constructable-stylesheets-adoptedstylesheets">Constructable Stylesheets & adoptedStyleSheets</a></th>
               <td><a href="https://github.com/WICG/webcomponents/issues/169">WICG/webcomponents#468</a></td>
               <td>Some implementation</td>
             </tr>
@@ -384,7 +384,7 @@
         <ul>
           <li>There is no effective way to share styles across components while allowing them to be centrally modified.</li>
           <li>Creating `&lt;style&gt;` elements for each style used in each shadow root has a measurable performance overhead.</li>
-          <li>CSS Module Scripts, another critical feature, depends on constructible stylesheets.</li>
+          <li>CSS Module Scripts, another critical feature, depends on constructable stylesheets.</li>
         </ul>
       </section>
       <section>
@@ -522,7 +522,7 @@
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>Should these two ideas can/should really ship separately? While the reflection API was ideated after the delegation API it may not be practical to separate them at the implementation/comsuption level.</li>
+          <li>Should these two ideas can/should really ship separately? While the reflection API was ideated after the delegation API it may not be practical to separate them at the implementation/consumption level.</li>
           <li>Is `delegation` and `reflection` the right name for these APIs? Particularly, "reflection" is used in <a href="https://wicg.github.io/aom/aria-reflection-explainer.html" target="_blank">ARIA Reflection</a>.</li>
           <li>There are non-ARIA attributes that would benefit from being supported by these APIs. Should they be drafted in a more general way?</li>
         </ul>
@@ -544,7 +544,7 @@
       </section>
       <section>
         <h3>Description</h3>
-        <p>CSS Module Scripts allow JavaScript modules to import style sheets. They can then be applied to a document or shadow root using adoptedStyleSheets in the same way as constructible style sheets.</p>
+        <p>CSS Module Scripts allow JavaScript modules to import style sheets. They can then be applied to a document or shadow root using adoptedStyleSheets in the same way as constructable style sheets.</p>
       </section>
       <section>
         <h3>Status</h3>


### PR DESCRIPTION
More minor things I found
1. Spelling mistakes
1. Consistent spelling of _Constructable_ (Stylesheets)
1. Formatting
1. Broken link